### PR TITLE
Simplify IFCA drain resolving

### DIFF
--- a/src/ifca/processing-queue.ts
+++ b/src/ifca/processing-queue.ts
@@ -1,0 +1,171 @@
+import { DroppedChunk, MaybePromise } from "../types";
+import { createResolvablePromiseObject, getId } from "../utils";
+
+export class ProcessingQueue<TYPE> {
+    /**
+     * Creates instance of ProcessingQueue.
+     *
+     * @param {Function} whenEmitted Callback function called each time any chunk leaves the queue.
+     */
+    constructor(whenEmitted: () => void) {
+        this.whenEmitted = whenEmitted;
+    }
+
+    /**
+     * Instance unique id.
+     */
+    public id = getId("IFCA:ProcessingQueue");
+
+    /**
+     * Ready chunks waitng to be read.
+     */
+    private _ready: TYPE[] = [];
+
+    /**
+     * Awaitng chunk requests.
+     */
+    private _requested: Object[] = [];
+
+    /**
+     * Number of chunks processed at the given moment.
+     */
+    private _pendingLength: number = 0;
+
+    /**
+     * Whenever the queue is closed.
+     */
+    private _hasEnded: Boolean = false;
+
+    /**
+     * Last chunk which was pushed to the queue.
+     */
+    private previousChunk: Promise<TYPE | void> = Promise.resolve();
+
+    /**
+     * Callback function called each time any chunk leaves the queue.
+     */
+    private whenEmitted: () => void;
+
+    /**
+     * @returns {number} Number of chunks (both being processed and ready) in the queue at the given moment.
+     */
+    get length(): number {
+        return this._pendingLength + this._ready.length;
+    }
+
+    /**
+     * @returns {number} Number of chunks processed at the given moment.
+     */
+    get pendingLength(): number {
+        return this._pendingLength;
+    }
+
+    /**
+     * Last chunk which was pushed to the queue.
+     * If there were no chunks pushed, resolved promise is returned.
+     *
+     * @returns {Promise<TYPE|void>} Last chunk from the queue.
+     */
+    get last(): Promise<TYPE|void> {
+        return this.previousChunk;
+    }
+
+    /**
+     * Adds chunk promise to the queue.
+     *
+     * @param {Promise<TYPE>} chunkResolver Promise resolving to a chunk.
+     * @returns {void}
+     */
+    push(chunkResolver: Promise<TYPE>): void {
+        // We don't need to worry about chunks resolving order since it is guaranteed
+        // by IFCA with Promise.all[previousChunk, currentChunk].
+        chunkResolver.then((result: TYPE) => {
+            this._pendingLength--;
+
+            if (result as any !== DroppedChunk) {
+                this._ready.push(result);
+
+                // If there is any chunk requested (read awaiting) resolve it.
+                if (this._requested.length) {
+                    const chunkRequest: any = this._requested.shift();
+
+                    chunkRequest.resolver(this._ready.shift() as TYPE);
+
+                    this.whenEmitted();
+                }
+            } else {
+                // Dropped chunks also means queue length changes.
+                this.whenEmitted();
+            }
+
+            // If queue is closed and there are no more pending items we need to make sure
+            // to resolve all waiting chunks requests (with nulls since there is no more data).
+            if (this._hasEnded) {
+                this.resolveAwaitingRequests();
+            }
+        });
+
+        this._pendingLength++;
+
+        this.previousChunk = chunkResolver;
+    }
+
+    /**
+     * Reads chunk from the queue.
+     *
+     * If there are ready chunks waiting, value is returned. If not, a promise
+     * which will resolved upon next chunk processing completes is returned.
+     *
+     * If the queue is closed and no more data avaialbe, `null`s are retruned.
+     *
+     * @returns {MaybePromise<TYPE|null>} Promise resolving to a chunk or chunk.
+     */
+    read(): MaybePromise<TYPE|null> {
+        // If chunk is ready, simply return it.
+        if (this._ready.length) {
+            // TODO handle nulls?
+
+            const chunk = this._ready.shift() as TYPE;
+
+            this.whenEmitted();
+
+            return chunk;
+        }
+
+        // Add chunk request to a queue if:
+        // * queue is not closed and there are no ready chunks
+        // * queue is closed but there are still pending chunks
+        if (!this._hasEnded || this._hasEnded && this._pendingLength > 0) {
+            const chunkRequest = createResolvablePromiseObject();
+
+            this._requested.push(chunkRequest);
+
+            return chunkRequest.promise as Promise<TYPE>;
+        }
+
+        return null;
+    }
+
+    /**
+     * Closes the queue and resolves all awaiting chunk requests.
+     *
+     * @returns {void}
+     */
+    close() {
+        this._hasEnded = true;
+        this.resolveAwaitingRequests();
+    }
+
+    /**
+     * Resolves all awaiting chunk requests which cannot be resolved due to end of data.
+     *
+     * @returns {void}
+     */
+    private resolveAwaitingRequests() {
+        if (this._hasEnded && this._pendingLength === 0 && this._requested.length > 0) {
+            for (const chunkRequest of this._requested) {
+                (chunkRequest as any).resolver(null);
+            }
+        }
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,11 +43,16 @@ function isAsyncTransformHandler(func: TransformHandler<any, any>): boolean {
     return isAsyncFunction(func[0]) || isAsyncFunction(func[1]);
 }
 
+function getId(prefix: string): string {
+    return `${ prefix }-${ Date.now() }`;
+}
+
 export {
     trace,
     createResolvablePromiseObject,
     isIterable,
     isAsyncIterable,
     isAsyncFunction,
-    isAsyncTransformHandler
+    isAsyncTransformHandler,
+    getId
 };

--- a/test/unit/ifca/oal.spec.ts
+++ b/test/unit/ifca/oal.spec.ts
@@ -11,7 +11,7 @@ test("Acceptable latency test", async (t) => {
     let sum: bigint = BigInt(0);
     let cnt = BigInt(0);
 
-    const ifca = new IFCA<{ i: any }, {i: number, ts: number}, any>({ maxParallel: MAX_PARALLEL })
+    const ifca = new IFCA<{ i: number}, {i: number, ts: number}, any>({ maxParallel: MAX_PARALLEL })
         .addTransform(({ i }: {i: number}) => ({ i, ts: process.hrtime.bigint() }))
         .addTransform(({ i, ts }) => ({ i, latency: process.hrtime.bigint() - ts }));
 

--- a/test/unit/ifca/test.spec.ts
+++ b/test/unit/ifca/test.spec.ts
@@ -432,22 +432,6 @@ for (const strict of [true, false]) {
         t.throws(ifca.end);
     });
 
-    test(`Writitng null chunk to IFCA triggers end (strict: ${ strict })`, async (t) => {
-        const ifca = new IFCA<number>({ maxParallel: 2, strict}).addTransform(x => x+1);
-
-        const whenEnded = ifca.whenEnded();
-
-        for (let i = 0; i < 4; i++) {
-            ifca.write(i);
-        }
-
-        ifca.write(null);
-
-        await whenEnded;
-
-        t.pass();
-    });
-
     test(`Writitng to IFCA after it's ended throws an error (write) (strict: ${ strict })`, async (t) => {
         const ifca = new IFCA<number>({ maxParallel: 2, strict}).addTransform(x => x+1);
 
@@ -586,14 +570,14 @@ for (const strict of [true, false]) {
 
         // processing queue [0, 1, 2, 3]
         // ready queue []
-        t.deepEqual({pending: 4, all: 4}, ifca.state);
+        t.like(ifca.state, {pending: 4, all: 4});
         t.deepEqual(mapDrainsArray(drains1), [undefined, "Promise", "Promise", "Promise"]);
 
         await ifca.end();
 
         // processing queue []
         // ready queue [0, 1, 2, 3]
-        t.deepEqual({pending: 0, all: 4}, ifca.state);
+        t.like(ifca.state, {pending: 0, all: 4});
         t.deepEqual(mapDrainsArray(drains1), [undefined, "Promise", "Promise", "Promise"]);
 
         for (let i = 0; i < 4; i++) {
@@ -605,7 +589,7 @@ for (const strict of [true, false]) {
 
         // processing queue []
         // ready queue []
-        t.deepEqual({pending: 0, all: 0}, ifca.state);
+        t.like(ifca.state, {pending: 0, all: 0});
         t.deepEqual(mapDrainsArray(drains1), [undefined, "ResolvedPromise", "ResolvedPromise", "ResolvedPromise"]);
     });
 }


### PR DESCRIPTION
Extracted from #33.

Drain resolving is now triggered by `ProcessingQueue` (as a callback passed from IFCA) whenever any chunk leaves the queue. It solves the issue where IFCA draining in `.finally` clause was called before queue pending length changed in `.then` clause added after mentioned `.finally` during runtime.