### PR TITLE
Introduce 'StringStream.grep()' method

### DIFF
--- a/src/streams/string-stream.ts
+++ b/src/streams/string-stream.ts
@@ -73,6 +73,10 @@ export class StringStream extends DataStream<string> {
         return super.map(callback, ...args);
     }
 
+    grep(pattern: RegExp): StringStream {
+        return this.filter(chunk => pattern.test(chunk));
+    }
+
     protected createChildStream(): StringStream {
         this.readable = false;
         this.transformable = false;

--- a/test/unit/streams/string/grep.spec.ts
+++ b/test/unit/streams/string/grep.spec.ts
@@ -1,0 +1,9 @@
+import test from "ava";
+import { StringStream } from "../../../../src/streams/string-stream";
+
+test("StringStream grep filters out chunks not matching passed pattern", async (t) => {
+    const stringStream = StringStream.from(["John", "Johnatan", "Johannes", "James", "Josh", "jelly", "joh"]);
+    const result = await stringStream.grep(/[J|j]ohn?/).toArray();
+
+    t.deepEqual(result, ["John", "Johnatan", "Johannes", "joh"]);
+});


### PR DESCRIPTION
Very similar to `.filter()` - it filters out chunks not matching passed regexp.

**Important**: Should be merged to `main` so need to wait until #33 is closed.