### PR TITLE
Introduce 'DataStream.run()' method

### DIFF
--- a/src/streams/base-stream.ts
+++ b/src/streams/base-stream.ts
@@ -16,4 +16,5 @@ export interface BaseStream<IN extends any, OUT extends any> {
     reduce<NEW_OUT>(
         callback: (previous: NEW_OUT, current: OUT) => MaybePromise<NEW_OUT>, initial?: NEW_OUT): Promise<NEW_OUT>;
     toArray(): Promise<OUT[]>;
+    run(): Promise<void>;
 }

--- a/src/streams/data-stream.ts
+++ b/src/streams/data-stream.ts
@@ -233,6 +233,11 @@ export class DataStream<IN, OUT = IN> implements BaseStream<IN, OUT>, AsyncItera
         return reader().then(() => chunks);
     }
 
+    @checkTransformability
+    async run(): Promise<void> {
+        return this.getReader(true, { onChunkCallback: () => {} })();
+    }
+
     // TODO
     // Helper created to be used in E2E test.
     // After DataStream will be a subclass of Transform, it can be simply piped to naitve writeStream.

--- a/test/unit/streams/data/run.spec.ts
+++ b/test/unit/streams/data/run.spec.ts
@@ -1,0 +1,13 @@
+import test from "ava";
+import { DataStream } from "../../../../src/streams/data-stream";
+
+test("DataStream run consumes entire stream", async (t) => {
+    const result: number[] = [];
+
+    await DataStream
+        .from([1, 2, 3, 4, 0, 0, 20, 10, 2, 2])
+        .map(x => { result.push(x); return x; })
+        .run();
+
+    t.deepEqual(result, [1, 2, 3, 4, 0, 0, 20, 10, 2, 2]);
+});


### PR DESCRIPTION
`DataStream.run()` consumes entire stream.