### PR TITLE
Add simple release test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:unit:w": "concurrently 'npm run build:w' 'sleep 8 && npm test:run:unit -- -w'",
     "test:unit:d": "npm run build && npm run test:run:unit -- debug --break",
     "test:bdd": "npm run build && npm run test:run:bdd",
+    "test:release": "cd test/release && ./run.sh",
     "dist": "rm -rf ./dist && tsc && node scripts/prepare-readme.js && node scripts/prepare-package.js",
     "lint": "eslint src/ test/ --ext .ts",
     "lint:f": "eslint src/ test/ --ext .ts --fix",

--- a/test/release/index.js
+++ b/test/release/index.js
@@ -1,0 +1,10 @@
+import { DataStream } from "@scramjet/framework";
+
+(async () => {
+    const result = await DataStream
+        .from(["It", "works", "!"])
+        .map(item => item.toUpperCase())
+        .reduce((prev, next) => `${prev} ${next}`);
+
+    console.log(result);
+})();

--- a/test/release/package.json
+++ b/test/release/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@scramjet/framework-release-test",
+  "main": "index.js",
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "AGPL-3.0",
+  "private": true,
+  "type": "module"
+}

--- a/test/release/run.sh
+++ b/test/release/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Installing $1 version..."
+
+npm i scramjet-framework-test@$1 --no-save
+
+echo "Starting test..."
+
+node index.js


### PR DESCRIPTION
Very simple script for testing framework package published to npm. This is complimentary PR to https://github.com/scramjetorg/docs/pull/104.

## Usage

```
npm run test:release -- version
```

This will not work yet, since we don't have anything published.